### PR TITLE
fix: add runtime.KeepAlive

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func test_without_unique_package() {
 		a[i] = ss[i%len(ss)]
 	}
 	log.Printf("test_without_unique_package: %v allocated", getAlloc()-before)
+	runtime.KeepAlive(a)
 }
 
 func test_with_unique_package() {
@@ -39,6 +40,7 @@ func test_with_unique_package() {
 		a[i] = unique.Make(ss[i%len(ss)])
 	}
 	log.Printf("test_with_unique_package: %v allocated", getAlloc()-before)
+	runtime.KeepAlive(a)
 }
 
 func main() {


### PR DESCRIPTION
I apologize for accidentally submitting a pull request to the example repository.

test_without_unique_package often print 0 allocated. I think there is a possible that slice `a` is garbage collected before print the method allocated size.  